### PR TITLE
Fix compare() in string_view

### DIFF
--- a/include/network/string_view.hpp
+++ b/include/network/string_view.hpp
@@ -161,8 +161,12 @@ class basic_string_view {
   }
 
   constexpr int compare(basic_string_view s) const noexcept {
-    return (size() != s.size()) ? (size() < s.size()) ? -1 : 1
-                                : traits::compare(data(), s.data(), size());
+    return size() == s.size()
+               ? traits::compare(data(), s.data(), size())
+               : (size() < s.size()
+                      ? (traits::compare(data(), s.data(), size()) > 0 ? 1 : -1)
+                      : (traits::compare(data(), s.data(), size()) < 0 ? -1
+                                                                       : 1));
   }
 
   constexpr int compare(size_type pos1, size_type n1,


### PR DESCRIPTION
I found a bug in string_view::compare.

When I test with following codes:
```
#include <gtest/gtest.h>
#include <network/uri.hpp>

TEST(uri, uri_string_compare) {
    EXPECT_EQ(network::string_view("http").compare("https"), strcmp("http", "https"));
    EXPECT_EQ(network::string_view("http").compare("rtp"), strcmp("http", "rtp"));
    EXPECT_EQ(network::string_view("http").compare("rtmpe"), strcmp("http", "rtmpe"));
}
```

It fails:
```
Running main() from gtest_main.cc
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from uri
[ RUN      ] uri.uri_string_compare
tests/uri.cpp:6: Failure
      Expected: network::string_view("http").compare("rtp")
      Which is: 1
To be equal to: strcmp("http", "rtp")
      Which is: -1
[  FAILED  ] uri.uri_string_compare (0 ms)
[----------] 1 test from uri (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (0 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] uri.uri_string_compare

 1 FAILED TEST
```
I committed a fix.
The codes are a bit lengthy because of the following compiler warnings and in avoidance of calling `traits::compare` twice in a single call.
```
error: variable declaration in a constexpr function is a C++14 extension [-Werror,-Wc++14-extensions]
```
